### PR TITLE
Basic tag implementation #4

### DIFF
--- a/PostingGuidelines.md
+++ b/PostingGuidelines.md
@@ -14,17 +14,21 @@ How To Post
 * Create a new branch for your post
 * Make sure you have an entry for your username in `_data/_authors.yml`
 * Use octopress to create a new post or page (recommended) `octopress new draft  title-of-post`
-    * Run jekyll serve with `-D` to display draft articles, and use [octopress](https://github.com/octopress/octopress) to publish when you are done revising (this will set the date for you) `octopress publish title-of-post`   
+    * Run jekyll serve with `-D` to display draft articles, and use [octopress](https://github.com/octopress/octopress) to publish when you are done revising (this will set the date for you) `octopress publish title-of-post`
 * To create a new post file manually, create a file in the `_posts` directory of the format `YYYY-MM-DD-TITLE.md` in the new file, include the below header information. Note the author field links to the reference in `_data/_authors.yml`:
 ```
 ---
 layout: post
 title: THE TITLE
-categories: [Jekyll]
-author: yang_li
+tags:
+    - jekyll
+authors:
+    - yang_li
 ---
 ```
 * Write your post
-* To see your post on a your local version of the blog before you publish it,  run `bundle exec jekyll serve` and and go to http://localhost:4000 (by default). 
+* Tags should be added in lower case, slug format; if you want to add a display name or description for a tag, add or update the entry in
+    `_data/_tags.yml`, which will be displayed on the tag index page.
+* To see your post on a your local version of the blog before you publish it,  run `bundle exec jekyll serve` and and go to http://localhost:4000 (by default).
 *  On GitHub create a [pull request](https://github.com/emory-libraries/emory-libraries.github.io/compare?expand=1) for others to review. Posts that fall under the "interesting tech" category do not need to be reviewed, thus they can be committed without a a pull request.
 *  All can ask questions and add comments, but the Ringleader for the iteration has the responsibility to review and merge (or not merge) the pull request to the main branch.  If the post is by the current Ringleader, or the Ringleader is unavailable due to being sick or on vacation, the responsibility falls to the next person on the list.

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,3 +5,6 @@
 
 - title: About
   url: /about/
+
+- title: Tags
+  url: /tags/

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,0 +1,9 @@
+# tag description and metadata
+# - if a name is specified here, it will be shown in the tag list
+#   instead of the slug
+# - if a tag description is here, it will be displayed on the tag index
+
+hydra:
+  description: "Work related to
+  <a href='https://projecthydra.org/'>Project Hydra</a>"
+

--- a/_includes/_list-post.html
+++ b/_includes/_list-post.html
@@ -1,0 +1,19 @@
+{% assign post=include.post %}
+<article>
+{% if post.link %}
+  <h2 class="link-post"><a href="{{ site.url }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a> <a href="{{ post.link }}" target="_blank" title="{{ post.title }}"><i class="fa fa-link"></i></a></h2>
+{% else %}
+  <h2><a href="{{ site.url }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></h2>
+  <p>{{ post.excerpt | strip_html | truncate: 160 }}</p>
+{% endif %}
+<p class="byline">
+    {% for post_author in post.authors %}
+        {% assign author = site.data.authors[post_author] %}
+        {{ author.name}}{% unless forloop.last %}, {% endunless %}
+    {% endfor %}
+    {% if include.show_date %}
+        | {{ post.date | date_to_long_string }}
+    {% endif %}
+    {% include _tags.html tags=post.tags %}
+</p>
+</article>

--- a/_includes/_tags.html
+++ b/_includes/_tags.html
@@ -1,0 +1,8 @@
+{% comment %}display and link tags on a post {% endcomment %}
+{% if include.tags.size %}
+    <div class="tags text-muted small align-right">
+    {% for tag in include.tags %}
+        <a href="{{ site.baseurl }}/tags/#{{ tag }}"><span property="schema:keywords">{{ tag }}</span></a>
+    {% endfor %}
+    </div>
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -42,12 +42,15 @@
     </div><!--/ .headline-wrap -->
     <div class="article-wrap">
       {{ content }}
+
+      {% include _tags.html tags=page.tags %}
       <hr />
       <footer role="contentinfo">
         {% if page.share != false %}{% include _social-share.html %}{% endif %}
         <p class="byline"><strong>{{ page.title }}</strong> was published on <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %d, %Y" }}</time>{% if page.modified %} and last modified on <time datetime="{{ page.modified | date: "%Y-%m-%d" }}">{{ page.modified | date: "%B %d, %Y" }}</time>{% endif %}.</p>
       </footer>
     </div><!-- /.article-wrap -->
+
   {% if site.owner.disqus-shortname and page.comments == true %}
     <section id="disqus_thread"></section><!-- /#disqus_thread -->
   {% endif %}

--- a/_layouts/tag-index.html
+++ b/_layouts/tag-index.html
@@ -30,20 +30,21 @@
 
 <div id="main" role="main">
   <div class="article-author-side">
-      {% include _org-info.html %}
+    {% include _org-info.html %}
   </div>
   <div id="index">
     <h1>{{ page.title }}</h1>
-    {% capture written_year %}'None'{% endcapture %}
-    {% for post in site.posts %}
-      {% capture year %}{{ post.date | date: '%Y' }}{% endcapture %}
-      {% if year != written_year %}
-        <h3>{{ year }}</h3>
-        {% capture written_year %}{{ year }}{% endcapture %}
-      {% endif %}
-      {% include _list-post.html post=post %}
-
+    {% for tag_info in site.tags %}
+        {% assign tag=tag_info[0] %} {% assign posts=tag_info[1] %} {% assign tag_data=site.data.tags[tag] %}
+        <a name="{{ tag }}"><h2 class="tag">{% if tag_data.name %}{{ tag_data.name }}{% else %}{{ tag }}{% endif %}</h2></a>
+        {% if tag_data.description %}
+          <p class="description">{{ tag_data.description %}}</p>
+        {% endif %}
+        {% for post in posts %}
+            {% include _list-post.html post=post show_date=true %}
+        {% endfor %}
     {% endfor %}
+
   </div><!-- /#index -->
 </div><!-- /#main -->
 

--- a/_posts/2016-04-10-piwik-setup-and-configuration-notes.md
+++ b/_posts/2016-04-10-piwik-setup-and-configuration-notes.md
@@ -1,8 +1,8 @@
 ---
 layout: post
 title: Piwik Setup and Configuration Notes  
-tags: 
-  - jekyll
+tags:
+    - jekyll
 authors:
     - yang_li
 ---

--- a/_posts/2016-04-10-piwik-setup-and-configuration-notes.md
+++ b/_posts/2016-04-10-piwik-setup-and-configuration-notes.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: Piwik Setup and Configuration Notes  
-categories: [Jekyll]
+tags: 
+  - jekyll
 authors:
     - yang_li
 ---

--- a/_posts/2016-04-13-jekyll-setup-and-configuration-notes.md
+++ b/_posts/2016-04-13-jekyll-setup-and-configuration-notes.md
@@ -2,7 +2,7 @@
 layout: post
 title: Jekyll Setup and Configuration Notes  
 tags:
-    - Jekyll
+    - jekyll
 authors:
     - yang_li
 ---

--- a/_posts/2016-04-13-jekyll-setup-and-configuration-notes.md
+++ b/_posts/2016-04-13-jekyll-setup-and-configuration-notes.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: Jekyll Setup and Configuration Notes  
-categories: [Jekyll]
+tags:
+    - Jekyll
 authors:
     - yang_li
 ---

--- a/_posts/2016-04-15-front-end-testing-research-notes.md
+++ b/_posts/2016-04-15-front-end-testing-research-notes.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: Front-end Testing Research Notes
-categories: [Jekyll]
+tags: 
+    - jekyll
 authors:
     - yang_li
 ---

--- a/_posts/2016-04-15-random-but-useful-technologies-for-share.md
+++ b/_posts/2016-04-15-random-but-useful-technologies-for-share.md
@@ -1,7 +1,10 @@
 ---
 layout: post
 title: Random but Useful Technologies for Share
-categories: [packages, tools, development]
+tags: 
+    - packages
+    - tools
+    - development
 authors:
     - yang_li
 ---

--- a/_posts/2016-04-18-hydra-sandbox-setup-and-configuration-notes.md
+++ b/_posts/2016-04-18-hydra-sandbox-setup-and-configuration-notes.md
@@ -1,7 +1,10 @@
 ---
 layout: post
 title: Hydra Sandbox Setup and Configuration Notes
-categories: [hydra, sandbox, development]
+tags: 
+    - hydra
+    - sandbox
+    - development
 authors:
     - yang_li
 ---

--- a/_sass/site.scss
+++ b/_sass/site.scss
@@ -70,3 +70,23 @@
 b, i, strong, em, blockquote, p, q, span, figure, img, h1, h2, header, input, a {
 	@include transition(all .2s ease);
 }
+
+/* style for post tags */
+.tags {
+  font-size: 85%;
+  color: gray;
+  text-align: right;
+  clear: right;
+  margin-top: -15px;
+}
+.tags span {
+  padding-left: 5px;
+}
+.tags span:before {
+  content: "#";
+}
+
+.description {
+    font-weight: 85%;
+    font-style: italic;
+}

--- a/_templates/post
+++ b/_templates/post
@@ -4,5 +4,8 @@ title: {{ title }}
 modified:
 categories: {{ dir }}
 excerpt:
-tags: []
+authors:
+   -
+tags:
+   -
 ---

--- a/tags.md
+++ b/tags.md
@@ -1,0 +1,5 @@
+---
+layout: tag-index
+title: Posts by Tag
+permalink: /tags/
+---


### PR DESCRIPTION
- convert existing post categories to tags
- new include for displaying tags
- new include for listing a post, with optional date
- tag index page, with list of posts by dags
- tag data, for optional tag name and description
- update posting guidelines with notes about tag use
